### PR TITLE
Fix : smaller icon will not hide

### DIFF
--- a/lib/src/widget/nav_bar_button.dart
+++ b/lib/src/widget/nav_bar_button.dart
@@ -134,7 +134,7 @@ class _NavBarButtonState extends State<NavBarButton>
                 begin: Offset.zero,
                 end: const Offset(
                   0,
-                  -1.0,
+                  -1.4,
                 ),
               ).animate(
                 CurvedAnimation(

--- a/lib/src/widget/nav_bar_button.dart
+++ b/lib/src/widget/nav_bar_button.dart
@@ -159,7 +159,7 @@ class _NavBarButtonState extends State<NavBarButton>
                 ),
                 end: const Offset(
                   0,
-                  -0.5,
+                  -0.8,
                 ),
               ).animate(
                 CurvedAnimation(

--- a/lib/src/widget/nav_bar_button.dart
+++ b/lib/src/widget/nav_bar_button.dart
@@ -159,7 +159,7 @@ class _NavBarButtonState extends State<NavBarButton>
                 ),
                 end: const Offset(
                   0,
-                  -0.8,
+                  -0.5,
                 ),
               ).animate(
                 CurvedAnimation(


### PR DESCRIPTION
Hey friend,
I'm using your beautiful widget with Feather_icons and when the text title appears the Icon does not hide completely, so I made this change.
![Screenshot_1637660242](https://user-images.githubusercontent.com/39870083/143001419-1104dcbd-ae44-44d2-b6e7-9032272c271a.png)
![Screenshot_1637660297](https://user-images.githubusercontent.com/39870083/143001428-899595d0-d0b5-456f-a5f7-38de13c7e955.png)

Please Accept my pull Request if you like.
Thank You!

